### PR TITLE
Feat/reactivate tags

### DIFF
--- a/backend/src/controllers/tag.controller.js
+++ b/backend/src/controllers/tag.controller.js
@@ -85,6 +85,30 @@ class tagController {
       return res.status(500).json({ error: "Falha ao desativar tag" });
     }
   }
+
+  async reativaTag(req, res) {
+
+    try {
+
+      const { id } = req.params;
+      const reactivated = await TagModel.reactivate(id);
+
+      if (!reactivated) {
+        return res.status(404).json({ error: "Tag não encontrada"});
+    }
+
+    return res.status(200).json({
+      message : "Tag reativada com sucesso",
+      tag: reactivated
+    });
+
+  } catch (error) {
+    console.log(error);
+    return res.status(500).json({ error: "Erro ao reativar tag"});
+  }
+
+  }
+
 }
 
 export default new tagController();

--- a/backend/src/models/tag.model.js
+++ b/backend/src/models/tag.model.js
@@ -41,8 +41,8 @@ class TagModel {
   
   // para buscar todas as tags ativas
   async findAll() {
-    // ORDER BY name ASC para ficar organizado alfabeticamente
-    const result = await pool.query("SELECT * FROM tb_tag WHERE active = true ORDER BY name ASC");
+    // const result = await pool.query("SELECT * FROM tb_tag WHERE active = true ORDER BY name ASC");
+    const result = await pool.query("SELECT * FROM tb_tag");
     return result.rows;
   }
 

--- a/backend/src/models/tag.model.js
+++ b/backend/src/models/tag.model.js
@@ -57,6 +57,20 @@ class TagModel {
 
     return result.rows[0];
   }
+
+async reactivate(id) {
+  const query = "UPDATE tb_tag SET active = true WHERE id = $1 RETURNING *";
+  const values = [id];
+
+  try {
+    const result = await pool.query(query, values);
+    return result.rows[0]; // retorna a tag atualizada
+  } catch (error) {
+    console.log("Erro no model ao reativar tag:", error);
+    throw error;
+  }
+}
+
 }
 
 export default new TagModel();

--- a/backend/src/routes/tag.route.js
+++ b/backend/src/routes/tag.route.js
@@ -166,4 +166,7 @@ router.delete(
   adminMiddleware,
   tagController.desativaTag
 );
+
+router.patch("/:id/reativar", TagController.reactivate);
+
 export default router;


### PR DESCRIPTION
- Alteração na consulta da rota `GET` de tags para retornar todos os registros (ignorando o filtro de status, trazendo ativas e inativas).
- Criação da rota `PATCH /tags/:id/reativar` para permitir a alteração do status de uma tag específica de `false` para `true`.